### PR TITLE
Update default CAS probe values

### DIFF
--- a/templates/cas_patch_probes.json
+++ b/templates/cas_patch_probes.json
@@ -6,8 +6,48 @@
 	},
 	{
 		"op": "replace",
+		"path": "/spec/livenessProbe/periodSeconds",
+		"value": 120,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/initialDelaySeconds",
+		"value": 3,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/timeoutSeconds",
+		"value": 60,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/failureThreshold",
+		"value": 5,
+	},
+	{
+		"op": "replace",
 		"path": "/spec/startupProbe/enabled",
 		"value": true,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/periodSeconds",
+		"value": 120,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/initialDelaySeconds",
+		"value": 180,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/timeoutSeconds",
+		"value": 60,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/failureThreshold",
+		"value": 5,
 	},
 	{
 		"op": "replace",

--- a/templates/cas_patch_probes_and_backup.json
+++ b/templates/cas_patch_probes_and_backup.json
@@ -21,8 +21,48 @@
 	},
 	{
 		"op": "replace",
+		"path": "/spec/livenessProbe/periodSeconds",
+		"value": 120,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/initialDelaySeconds",
+		"value": 3,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/timeoutSeconds",
+		"value": 60,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/livenessProbe/failureThreshold",
+		"value": 5,
+	},
+	{
+		"op": "replace",
 		"path": "/spec/startupProbe/enabled",
 		"value": true,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/periodSeconds",
+		"value": 120,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/initialDelaySeconds",
+		"value": 180,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/timeoutSeconds",
+		"value": 60,
+	},
+	{
+		"op": "replace",
+		"path": "/spec/startupProbe/failureThreshold",
+		"value": 5,
 	},
 	{
 		"op": "replace",


### PR DESCRIPTION
Change default CAS probe values to avoid unnecessary restarts on slow clusters.